### PR TITLE
Better extendability of library

### DIFF
--- a/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusEndpoint.scala
+++ b/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusEndpoint.scala
@@ -4,9 +4,8 @@ import java.nio.charset.Charset
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.actor.ActorRefFactory
-import com.monsanto.arch.kamon.prometheus.converter.SnapshotConverter
+import com.monsanto.arch.kamon.prometheus.converter.{MetricSubscriber}
 import com.monsanto.arch.kamon.prometheus.metric.{MetricFamily, ProtoBufFormat, TextFormat}
-import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import spray.http._
 import spray.httpx.marshalling.ToResponseMarshaller
 import spray.routing.Route
@@ -16,11 +15,9 @@ import spray.routing.Directives
   *
   * @author Daniel Solano Gómez
   */
-class PrometheusEndpoint(settings: PrometheusSettings)(implicit val actorRefFactory: ActorRefFactory) {
+class PrometheusEndpoint(implicit val actorRefFactory: ActorRefFactory) extends MetricSubscriber {
   import PrometheusEndpoint.{ProtoBufContentType, TextContentType}
 
-  /** Converts snapshots from Kamon’s native type to the one used by this extension. */
-  private val snapshotConverter = new SnapshotConverter(settings)
   /** Mutable cell with the latest snapshot. */
   private val snapshot = new AtomicReference[Seq[MetricFamily]]
 
@@ -56,8 +53,8 @@ class PrometheusEndpoint(settings: PrometheusSettings)(implicit val actorRefFact
   }
 
   /** Updates the endpoint's current snapshot atomically. */
-  def updateSnapShot(newSnapshot: TickMetricSnapshot): Unit = {
-    snapshot.set(snapshotConverter(newSnapshot))
+  def setMetrics(metrics: Seq[MetricFamily]): Unit = {
+    snapshot.set(metrics)
   }
 }
 

--- a/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusListener.scala
+++ b/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusListener.scala
@@ -2,16 +2,20 @@ package com.monsanto.arch.kamon.prometheus
 
 import akka.actor.{Actor, Props}
 import akka.event.Logging
+import com.monsanto.arch.kamon.prometheus.converter.{MetricSubscriber, SnapshotConverter}
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 
 /** An actor that receives messages from Kamon and updates the endpoint with the latest snapshot. */
-class PrometheusListener(endpoint: PrometheusEndpoint) extends Actor {
+class PrometheusListener(subscribers: Seq[MetricSubscriber], snapshotConverter: SnapshotConverter) extends Actor {
+
   private val log = Logging(context.system, this)
+
+  subscribers.foreach(s => snapshotConverter.registerSubscriber(s))
 
   override def receive = {
     case tick: TickMetricSnapshot => {
       log.debug(s"Got a tick: $tick")
-      endpoint.updateSnapShot(tick)
+      snapshotConverter(tick)
     }
     case x => {
       log.warning(s"Got an $x")
@@ -20,5 +24,5 @@ class PrometheusListener(endpoint: PrometheusEndpoint) extends Actor {
 }
 object PrometheusListener {
   /** Provides the props to create a new PrometheusListener. */
-  def props(endpoint: PrometheusEndpoint): Props = Props(new PrometheusListener(endpoint))
+  def props(subscribers: Seq[MetricSubscriber], snapshotConverter: SnapshotConverter): Props = Props(new PrometheusListener(subscribers, snapshotConverter))
 }

--- a/library/src/main/scala/com/monsanto/arch/kamon/prometheus/converter/MetricSubscriber.scala
+++ b/library/src/main/scala/com/monsanto/arch/kamon/prometheus/converter/MetricSubscriber.scala
@@ -1,0 +1,13 @@
+package com.monsanto.arch.kamon.prometheus.converter
+
+import com.monsanto.arch.kamon.prometheus.metric.MetricFamily
+
+/** Default interface to subscribe for metric updates
+  *
+  * @author Yegor Andreenko
+  */
+trait MetricSubscriber {
+
+  def setMetrics(metrics: Seq[MetricFamily])
+
+}


### PR DESCRIPTION
What I've created actually not the final thought, but an idea how the library could be extended.

Use case: I need to expose metrics in another place. (ex. at http endpoint in java spring application) 

To be able to do this I actually hacked SnapshotConverter class this way
 ```
 /** Converts a metric snapshot into a sequence of metric families. */
  def apply(tick: TickMetricSnapshot): Seq[MetricFamily] = {
    .........
    val metrics = byCategoryData.flatMap {
    .........
    }.map(postprocess(_)).toList
   // hack to expose metrics to custom KamonMetricsService
    KamonMetricsService.Instance.setMetrics(metrics)

    metrics
  }
```
The idea of PR is to `subscribe` to snapshots of Kamon to be able to use them at different places by different ways. Now the obvious subscriber is PrometheusEndpoint. 

Do you find it interesting? Could you come up with a extendable way to implement this?