### PR TITLE
Upgrading Kamon and Akka libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: scala
+scala:
+  - 2.11.7
 jdk:
   - oraclejdk8
 before_script:

--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,21 @@
 import java.util.Date
 import sbtprotobuf.ProtobufPlugin
 
-val akkaVersion = "2.3.14"
+val akkaVersion = "2.4.6"
 val sprayVersion = "1.3.3"
-val kamonVersion = "0.5.2"
+val kamonVersion = "0.6.2"
+scalaVersion in ThisBuild := "2.11.7"
 
 lazy val commonSettings = Seq(
   homepage := Some(url("https://monsantoco.github.io/kamon-prometheus")),
   organization := "com.monsanto.arch",
   organizationHomepage := Some(url("http://engineering.monsanto.org")),
   licenses := Seq("BSD New" → url("http://opensource.org/licenses/BSD-3-Clause")),
-  scalaVersion := "2.11.7",
+  scalaVersion := scalaVersion.value,
   scalacOptions ++= Seq(
     "-deprecation",
-    "-unchecked"
+    "-unchecked",
+    "-encoding", "utf8"
   ),
   resolvers += Resolver.jcenterRepo,
   apiMappingsScala ++= Map(
@@ -65,6 +67,7 @@ lazy val library = (project in file("library"))
       "com.typesafe.akka"      %% "akka-actor"               % akkaVersion,
       "com.typesafe"            % "config"                   % "1.3.0",
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4" % "provided",
+      //"org.slf4j" % "slf4j-simple" % "1.7.21",
       // -- testing --
       "org.scalatest"     %% "scalatest"     % "2.2.5"      % "test",
       "com.typesafe.akka" %% "akka-testkit"  % akkaVersion  % "test",

--- a/demo/src/main/scala/com/monsanto/arch/kamon/prometheus/demo/DemoServiceActor.scala
+++ b/demo/src/main/scala/com/monsanto/arch/kamon/prometheus/demo/DemoServiceActor.scala
@@ -91,7 +91,7 @@ class DemoServiceActor extends TracingHttpServiceActor {
   /** This directive creates the metrics endpoint at `/metrics` and names all traces which end up here ‘metrics’. */
   val metricsRoute =
     path("metrics") {
-      Kamon(Prometheus).route
+      Prometheus(context.system).route
     }
 }
 

--- a/library/src/main/resources/reference.conf
+++ b/library/src/main/resources/reference.conf
@@ -42,7 +42,7 @@ kamon {
     monsanto-kamon-prometheus {
       auto-start = yes
       requires-aspectj = no
-      extension-id = "com.monsanto.arch.kamon.prometheus.Prometheus"
+      extension-class = "com.monsanto.arch.kamon.prometheus.Prometheus"
     }
   }
 }

--- a/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusListener.scala
+++ b/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusListener.scala
@@ -9,13 +9,11 @@ class PrometheusListener(endpoint: PrometheusEndpoint) extends Actor {
   private val log = Logging(context.system, this)
 
   override def receive = {
-    case tick: TickMetricSnapshot => {
+    case tick: TickMetricSnapshot =>
       log.debug(s"Got a tick: $tick")
       endpoint.updateSnapShot(tick)
-    }
-    case x => {
+    case x =>
       log.warning(s"Got an $x")
-    }
   }
 }
 object PrometheusListener {

--- a/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusSettings.scala
+++ b/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusSettings.scala
@@ -3,6 +3,7 @@ package com.monsanto.arch.kamon.prometheus
 import akka.ConfigurationException
 import com.typesafe.config.{Config, ConfigFactory}
 import kamon.Kamon
+import kamon.metric.MetricsModule
 import kamon.util.ConfigTools.Syntax
 
 import scala.collection.JavaConversions
@@ -18,6 +19,8 @@ import scala.concurrent.duration.FiniteDuration
 class PrometheusSettings(config: Config) {
   config.checkValid(ConfigFactory.defaultReference(), "kamon.prometheus")
   private val prometheusConfig = config.getConfig("kamon.prometheus")
+
+  private def metrics: MetricsModule = Kamon.metrics
 
   /** The extension’s endpoint will serve new results according to this value. */
   val refreshInterval: FiniteDuration = prometheusConfig.getFiniteDuration("refresh-interval")
@@ -39,8 +42,8 @@ class PrometheusSettings(config: Config) {
   }
 
   // ensure that the refresh interval is not less than the tick interval
-  if (refreshInterval < Kamon.metrics.settings.tickInterval) {
-    val msg = s"The Prometheus refresh interval (${refreshInterval.toCoarsest}) must be equal to or greater than the Kamon tick interval (${Kamon.metrics.settings.tickInterval.toCoarsest})"
+  if (refreshInterval < metrics.settings.tickInterval) {
+    val msg = s"The Prometheus refresh interval (${refreshInterval.toCoarsest}) must be equal to or greater than the Kamon tick interval (${metrics.settings.tickInterval.toCoarsest})"
     throw new ConfigurationException(msg)
   }
 }

--- a/library/src/test/scala/com/monsanto/arch/kamon/prometheus/KamonTestKit.scala
+++ b/library/src/test/scala/com/monsanto/arch/kamon/prometheus/KamonTestKit.scala
@@ -1,94 +1,30 @@
 package com.monsanto.arch.kamon.prometheus
 
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKitBase}
 import com.monsanto.arch.kamon.prometheus.KamonTestKit.TestCurrentValueCollector
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import kamon.Kamon
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
-import kamon.metric.instrument.{UnitOfMeasurement, CollectionContext, Gauge}
-import kamon.metric.{Entity, SingleInstrumentEntityRecorder, SubscriptionsDispatcher}
+import kamon.metric.instrument.{CollectionContext, Gauge, UnitOfMeasurement}
+import kamon.metric._
 import kamon.util.{LazyActorRef, MilliTimestamp}
-import org.scalatest.Suite
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.collection.concurrent.TrieMap
 
 /** Utilities for testing with Kamon.
   *
   * @author Daniel Solano Gómez
   */
-trait KamonTestKit extends Suite {
-  /** The start time of generated snapshots. */
-  val start = MilliTimestamp.now
-  /** The end time of generated snapshots. */
-  val end = new MilliTimestamp(start.millis + 60000)
-
-  /** Takes a snapshot of the given entity and returns it. */
-  def snapshotOf(entities: Entity*): TickMetricSnapshot = {
-    val collectionContext = CollectionContext(entities.size * 10000)
-    val snapshots = entities.map {entity ⇒
-      val recorder = Kamon.metrics.find(entity)
-      assert(recorder.isDefined)
-      val snapshot = recorder.get.collect(collectionContext)
-      entity → snapshot
-    }.toMap
-    TickMetricSnapshot(start, end, snapshots)
+abstract class KamonTestKit(actorSystemName: String) extends TestKitBase with KamonTestLike with WordSpecLike with Matchers with ImplicitSender with BeforeAndAfterAll {
+  def config: Config = Kamon.config
+  implicit lazy val system: ActorSystem = {
+    Kamon.start()
+    clearMetrics()
+    ActorSystem(actorSystemName, config)
   }
-
-  /** Creates a new histogram and increments it by the given count.  Returns the entity for the counter. */
-  def counter(name: String, count: Long, tags: Map[String,String] = Map.empty,
-              unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown) = {
-    val c = Kamon.metrics.counter(name, tags, unitOfMeasurement)
-    c.increment(count)
-    Entity(name, SingleInstrumentEntityRecorder.Counter, tags)
-  }
-
-  /** Creates a new histogram and records the given values.  Returns the entity for the histogram. */
-  def histogram(name: String, values: Seq[Long] = Seq.empty, tags: Map[String,String] = Map.empty,
-                 unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown): Entity = {
-    val h = Kamon.metrics.histogram(name, tags, unitOfMeasurement)
-    values.foreach(h.record)
-
-    Entity(name, SingleInstrumentEntityRecorder.Histogram, tags)
-  }
-
-  /** Creates a new min-max counter and applies the given increments/decrements.  After every 5 changes, the counter
-    * is refreshed.  Returns the entity of the counter. */
-  def minMaxCounter(name: String, changes: Seq[Long] = Seq.empty, tags: Map[String,String] = Map.empty,
-                     unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown): Entity = {
-    val minMaxCounter = Kamon.metrics.minMaxCounter(name, tags, unitOfMeasurement)
-    changes.grouped(5).foreach { changesChunk ⇒
-      changesChunk.foreach(minMaxCounter.increment)
-      minMaxCounter.refreshValues()
-    }
-    Entity(name, SingleInstrumentEntityRecorder.MinMaxCounter, tags)
-  }
-
-  /** Creates a new gauge that will record the given values.  Returns the entity of the gauge. */
-  def gauge(name: String, readings: Seq[Long] = Seq.empty, tags: Map[String,String] = Map.empty,
-             unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown): Entity = {
-    val gauge = Kamon.metrics.gauge(name, tags, unitOfMeasurement)(new TestCurrentValueCollector(readings))
-    readings.foreach(_ ⇒ gauge.refreshValue())
-    Entity(name, SingleInstrumentEntityRecorder.Gauge, tags)
-  }
-
-  /** Starts and stops Kamon around each test. */
-  override def withFixture(test: NoArgTest) = {
-    val config = KamonTestKit.TestConfig.withFallback(ConfigFactory.load())
-    Kamon.start(config)
-    try {
-      super.withFixture(test)
-    } finally {
-      Kamon.shutdown()
-    }
-  }
-
-  /** Forcibly flushes all subscriptions.
-    *
-    * Taken from https://github.com/kamon-io/Kamon/blob/57dd25e3afbfc2682b81c07161850104f32fd841/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala#L54
-    */
-  def flushSubscriptions(): Unit = {
-    val subscriptionsField = Kamon.metrics.getClass.getDeclaredField("_subscriptions")
-    subscriptionsField.setAccessible(true)
-    val subscriptions = subscriptionsField.get(Kamon.metrics).asInstanceOf[LazyActorRef]
-    subscriptions.tell(SubscriptionsDispatcher.Tick)
-  }
+  override protected def afterAll(): Unit = system.terminate()
 }
 
 object KamonTestKit {
@@ -134,5 +70,116 @@ object KamonTestKit {
       }
       lastValue
     }
+  }
+}
+
+trait KamonTestLike {
+
+  /** The start time of generated snapshots. */
+  val start = MilliTimestamp.now
+  /** The end time of generated snapshots. */
+  val end = new MilliTimestamp(start.millis + 60000)
+
+  /** Takes a snapshot of the given entity and returns it. */
+  def snapshotOf(entities: Entity*): TickMetricSnapshot = {
+    val collectionContext = CollectionContext(entities.size * 10000)
+    val snapshots = entities.map {entity ⇒
+      val recorder = Kamon.metrics.find(entity)
+      assert(recorder.isDefined)
+      val snapshot = recorder.get.collect(collectionContext)
+      entity → snapshot
+    }.toMap
+    TickMetricSnapshot(start, end, snapshots)
+  }
+
+  /** Creates a new histogram and increments it by the given count.  Returns the entity for the counter. */
+  def counter(name: String, count: Long, tags: Map[String,String] = Map.empty,
+              unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown) = {
+    val c = Kamon.metrics.counter(name, tags, unitOfMeasurement)
+    c.increment(count)
+    Entity(name, SingleInstrumentEntityRecorder.Counter, tags)
+  }
+
+  def removeCounter(entity: Entity) = Kamon.metrics.removeCounter(entity.name, entity.tags)
+
+  /** Creates a new histogram and records the given values.  Returns the entity for the histogram. */
+  def histogram(name: String, values: Seq[Long] = Seq.empty, tags: Map[String,String] = Map.empty,
+                unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown): Entity = {
+    val h = Kamon.metrics.histogram(name, tags, unitOfMeasurement)
+    values.foreach(h.record)
+
+    Entity(name, SingleInstrumentEntityRecorder.Histogram, tags)
+  }
+
+  def removeHistogram(entity: Entity) = Kamon.metrics.removeHistogram(entity.name, entity.tags)
+
+  /** Creates a new min-max counter and applies the given increments/decrements.  After every 5 changes, the counter
+    * is refreshed.  Returns the entity of the counter. */
+  def minMaxCounter(name: String, changes: Seq[Long] = Seq.empty, tags: Map[String,String] = Map.empty,
+                    unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown): Entity = {
+    val minMaxCounter = Kamon.metrics.minMaxCounter(name, tags, unitOfMeasurement)
+    changes.grouped(5).foreach { changesChunk ⇒
+      changesChunk.foreach(minMaxCounter.increment)
+      minMaxCounter.refreshValues()
+    }
+    Entity(name, SingleInstrumentEntityRecorder.MinMaxCounter, tags)
+  }
+
+  def removeMinMaxCounter(entity: Entity) = Kamon.metrics.removeMinMaxCounter(entity.name, entity.tags)
+
+  /** Creates a new gauge that will record the given values.  Returns the entity of the gauge. */
+  def gauge(name: String, readings: Seq[Long] = Seq.empty, tags: Map[String,String] = Map.empty,
+            unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown): Entity = {
+    val gauge = Kamon.metrics.gauge(name, tags, unitOfMeasurement)(new TestCurrentValueCollector(readings))
+    readings.foreach(_ ⇒ gauge.refreshValue())
+    Entity(name, SingleInstrumentEntityRecorder.Gauge, tags)
+  }
+
+  def removeGauge(entity: Entity) = Kamon.metrics.removeGauge(entity.name, entity.tags)
+
+  def removeEntity(entity: Entity) = Kamon.metrics.removeEntity(entity)
+
+  /** Forcibly flushes all subscriptions.
+    *
+    * Taken from https://github.com/kamon-io/Kamon/blob/57dd25e3afbfc2682b81c07161850104f32fd841/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala#L54
+    */
+  def flushSubscriptions(): Unit = {
+    val subscriptionsField = Kamon.metrics.getClass.getDeclaredField("_subscriptions")
+    subscriptionsField.setAccessible(true)
+    val subscriptions = subscriptionsField.get(Kamon.metrics).asInstanceOf[LazyActorRef]
+    subscriptions.tell(SubscriptionsDispatcher.Tick)
+  }
+
+  def kamonSystem = {
+    val systemField = Kamon.getClass.getDeclaredField("_system")
+    systemField.setAccessible(true)
+    systemField.get(Kamon).asInstanceOf[ActorSystem]
+  }
+
+  def kamonConfig(config: Config): Unit = {
+    import scala.reflect.runtime.universe._
+
+    val m = runtimeMirror(Kamon.getClass.getClassLoader)
+    val im = m.reflect(Kamon)
+    val decl = im.symbol.asType.toType.decl(TermName("config")).asTerm
+    val fm = im.reflectField(decl)
+    fm.set(config)
+
+    val settings = MetricsSettings(config)
+
+    val m1 = runtimeMirror(Kamon.getClass.getClassLoader)
+    val im1 = m1.reflect(Kamon.metrics)
+    val decl1 = im1.symbol.asType.toType.decl(TermName("settings")).asTerm
+    val fm1 = im1.reflectField(decl1)
+    fm1.set(settings)
+  }
+
+  def clearMetrics() = {
+    import scala.reflect.runtime.universe._
+    val m1 = runtimeMirror(Kamon.getClass.getClassLoader)
+    val im1 = m1.reflect(Kamon.metrics)
+    val decl1 = im1.symbol.asType.toType.decl(TermName("_trackedEntities")).asTerm
+    val fm1 = im1.reflectField(decl1)
+    fm1.set(TrieMap.empty[Entity, EntityRecorder])
   }
 }

--- a/library/src/test/scala/com/monsanto/arch/kamon/prometheus/PrometheusExtensionSettingsSpec.scala
+++ b/library/src/test/scala/com/monsanto/arch/kamon/prometheus/PrometheusExtensionSettingsSpec.scala
@@ -1,9 +1,11 @@
 package com.monsanto.arch.kamon.prometheus
 
 import akka.ConfigurationException
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import kamon.Kamon
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{Matchers, WordSpecLike}
 
 import scala.concurrent.duration.DurationInt
 
@@ -11,64 +13,56 @@ import scala.concurrent.duration.DurationInt
   *
   * @author Daniel Solano Gómez
   */
-class PrometheusExtensionSettingsSpec extends WordSpec with Matchers {
+class PrometheusExtensionSettingsSpec extends KamonTestKit("PrometheusExtensionSettingsSpec") {
   import PrometheusExtensionSettingsSpec._
-
-  /** Stops Kamon after each test. */
-  override def withFixture(test: NoArgTest) = {
-    try {
-      super.withFixture(test)
-    } finally {
-      try {
-        Kamon.shutdown()
-      } catch {
-        case _: NullPointerException ⇒ // occurs if Kamon did not start
-      }
-    }
-  }
 
   "the Prometheus extension" when {
     "loading settings" should {
       "load the default configuration" in {
-        Kamon.start(NoKamonLoggingConfig)
-        val settings = Kamon.extension(Prometheus).settings
+        val _system = ActorSystem("ext_test_0", NoKamonLoggingConfig)
+        val settings = Prometheus(_system).settings
 
         settings.refreshInterval shouldBe 1.minute
         settings.subscriptions shouldBe DefaultSubscriptions
         settings.labels shouldBe Map.empty[String,String]
+        _system.terminate()
       }
 
       "reject configurations where the refresh interval is too short" in {
         val config = ConfigFactory.parseString("kamon.prometheus.refresh-interval = 30 milliseconds")
-
-        Kamon.start(config.withFallback(NoKamonLoggingConfig))
+        val _system = ActorSystem("ext_test_1", config.withFallback(NoKamonLoggingConfig))
         the [ConfigurationException] thrownBy {
-          Kamon(Prometheus)
+          Prometheus(_system)
         } should have message "The Prometheus refresh interval (30 milliseconds) must be equal to or greater than the Kamon tick interval (10 seconds)"
+        _system.terminate()
       }
 
       "respect a refresh interval setting" in {
         val config = ConfigFactory.parseString("kamon.prometheus.refresh-interval = 1000.days")
-        Kamon.start(config.withFallback(NoKamonLoggingConfig))
-        Kamon(Prometheus).settings.refreshInterval shouldBe 1000.days
+        val _system = ActorSystem("ext_test_2", config.withFallback(NoKamonLoggingConfig))
+        Prometheus(_system).settings.refreshInterval shouldBe 1000.days
+        _system.terminate()
       }
 
       "respect an overridden subscription setting" in {
         val config = ConfigFactory.parseString("kamon.prometheus.subscriptions.counter = [ \"foo\" ]")
-        Kamon.start(config.withFallback(NoKamonLoggingConfig))
-        Kamon(Prometheus).settings.subscriptions shouldBe DefaultSubscriptions.updated("counter", List("foo"))
+        val _system = ActorSystem("ext_test_3", config.withFallback(NoKamonLoggingConfig))
+        Prometheus(_system).settings.subscriptions shouldBe DefaultSubscriptions.updated("counter", List("foo"))
+        _system.terminate()
       }
 
       "respect an additional subscription setting" in {
         val config = ConfigFactory.parseString("kamon.prometheus.subscriptions.foo = [ \"bar\" ]")
-        Kamon.start(config.withFallback(NoKamonLoggingConfig))
-        Kamon(Prometheus).settings.subscriptions shouldBe DefaultSubscriptions + ("foo" → List("bar"))
+        val _system = ActorSystem("ext_test_4", config.withFallback(NoKamonLoggingConfig))
+        Prometheus(_system).settings.subscriptions shouldBe DefaultSubscriptions + ("foo" → List("bar"))
+        _system.terminate()
       }
 
       "respect configured labels" in {
         val config = ConfigFactory.parseString("kamon.prometheus.labels.foo = \"bar\"")
-        Kamon.start(config.withFallback(NoKamonLoggingConfig))
-        Kamon(Prometheus).settings.labels shouldBe Map("foo" → "bar")
+        val _system = ActorSystem("ext_test_5", config.withFallback(NoKamonLoggingConfig))
+        Prometheus(_system).settings.labels shouldBe Map("foo" → "bar")
+        _system.terminate()
       }
     }
 
@@ -79,11 +73,12 @@ class PrometheusExtensionSettingsSpec extends WordSpec with Matchers {
             |kamon.metric.tick-interval = 2 minutes
           """.stripMargin).withFallback(NoKamonLoggingConfig)
 
-        Kamon.start(config)
+        val _system = ActorSystem("ext_test_6", config)
 
-        val extension = Kamon.extension(Prometheus)
+        val extension = Prometheus(_system)
         extension.isBuffered shouldBe true
         extension.listener should not be theSameInstanceAs(extension.buffer)
+        _system.terminate()
       }
 
       "not buffer when the refresh interval is the same as the tick interval" in {
@@ -92,11 +87,16 @@ class PrometheusExtensionSettingsSpec extends WordSpec with Matchers {
             |kamon.metric.tick-interval = 42 days
           """.stripMargin).withFallback(NoKamonLoggingConfig)
 
-        Kamon.start(config)
+        val origConfig = Kamon.config
+        kamonConfig(config)
 
-        val extension = Kamon.extension(Prometheus)
+        val _system = ActorSystem("ext_test_7", config)
+
+        val extension = Prometheus(_system)
         extension.isBuffered shouldBe false
         extension.listener shouldBe theSameInstanceAs(extension.buffer)
+        _system.terminate()
+        kamonConfig(origConfig)
       }
     }
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version = 0.13.11
+sbt.version = 0.13.12
+


### PR DESCRIPTION
Hello,

This PR upgrades Akka and Kamon to more recent versions. It's not in this scope to do changes to Spray.

It also aims to separate Spray external representation from the snapshot internal representation to improve reusability - something I need for for company project where I already have an endpoint setup with metrics from other metric libraries and it's easier to compose.

Given the state of Kamon and testability, some tests were refactored to do further cleanup and others use reflection to keep existing tests working.

Please do have a look at these changes as I would like to use a release of this in a production server as soon as your convenience.

Let me know if there's anything I can assist with.