### PR TITLE
Simplify build setup removing dependency on protoc binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ scala:
   - 2.11.8
 jdk:
   - oraclejdk8
-before_script:
-  - wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
-  - tar -xvf protobuf-2.6.1.tar.gz
-  - cd protobuf-2.6.1 && ./configure && make && sudo make install && sudo ldconfig && cd ..
 script:
   - sbt clean buffered-config-test:test invalid-config-test:test coverage test coverageReport && sbt coverageAggregate
 after_success:

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -245,12 +245,7 @@ Development
 [[building]]
 === Building the library
 
-You can use `sbt` to build the library, but you will need to have Google’s
-protocol buffers compiler `protoc` on your path.  You can
-https://developers.google.com/protocol-buffers/docs/downloads[download]
-Protocol buffers directly from Google.  However, there may be simpler options.
-For example, on OS X, you can use http://brew.sh[homebrew] and just `brew
-install protobuf`.
+You can use `sbt` to build the library.
 
 Additionally, to build the demo, you will need to have Docker set up.
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,9 @@ lazy val library = (project in file("library"))
       "org.scala-lang"          % "scala-reflect" % scalaVersion.value,
       "org.scala-lang.modules" %% "scala-xml"     % "1.0.6"
     ),
-    version in ProtobufPlugin.protobufConfig := "2.6.1",
+    ProtobufPlugin.runProtoc in ProtobufPlugin.protobufConfig := { args =>
+      com.github.os72.protocjar.Protoc.runProtoc( args.toArray)
+    },
 
     // We have to ensure that Kamon starts/stops serially
     parallelExecution in Test := false,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.2")
 
-addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.5.3")
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.5.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 
@@ -24,4 +24,8 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
 dependencyOverrides ++= Set(
   "com.typesafe.sbt" % "sbt-site" % "0.8.2"
+)
+
+libraryDependencies ++= Seq(
+  "com.github.os72" % "protoc-jar" % "2.6.1.4"
 )


### PR DESCRIPTION
Simplify build setup removing dependency on protoc binary, use
protojar to bring protoc binary at build time.