### PR TITLE
Histogram buckets should have _bucket suffix in text format

### DIFF
--- a/library/src/main/scala/com/monsanto/arch/kamon/prometheus/metric/TextFormat.scala
+++ b/library/src/main/scala/com/monsanto/arch/kamon/prometheus/metric/TextFormat.scala
@@ -19,8 +19,8 @@ object TextFormat extends SerialisationFormat[String] {
           case MetricValue.Counter(c) ⇒ Seq(formatLine(family.name, metric.labels, c, metric.timestamp))
           case MetricValue.Histogram(buckets, count, sum) ⇒
             buckets.map { bucket ⇒
-              formatLine(family.name, metric.labels + ("le" → formatValue(bucket.upperBound)), bucket.cumulativeCount,
-                metric.timestamp)
+              formatLine(family.name + "_bucket", metric.labels + ("le" → formatValue(bucket.upperBound)),
+                bucket.cumulativeCount, metric.timestamp)
             } ++ Seq(
               formatLine(family.name + "_count", metric.labels, count, metric.timestamp),
               formatLine(family.name + "_sum", metric.labels, sum, metric.timestamp)
@@ -225,7 +225,7 @@ object TextFormat extends SerialisationFormat[String] {
           val CountName = s"${name}_count"
           val foo =
           histogramGroups.map { case (labels, lines) ⇒
-            val (bucketLines, otherLines) = lines.span(_.name == name)
+            val (bucketLines, otherLines) = lines.span(_.name == name+"_bucket")
             val buckets = bucketLines.map { line ⇒
               MetricValue.Bucket(parseValue(line.labels("le")), line.value.toLong)
             }

--- a/library/src/test/scala/com/monsanto/arch/kamon/prometheus/metric/GaugeSerialisationFixture.scala
+++ b/library/src/test/scala/com/monsanto/arch/kamon/prometheus/metric/GaugeSerialisationFixture.scala
@@ -45,11 +45,11 @@ trait GaugeSerialisationFixture {
   /** The snapshot as a string. */
   val snapshotString =
     s"""# TYPE $name histogram
-       |$name{$labelString,le="1.0"} 2.0 ${timestamp.millis}
-       |$name{$labelString,le="4.0"} 4.0 ${timestamp.millis}
-       |$name{$labelString,le="6.0"} 5.0 ${timestamp.millis}
-       |$name{$labelString,le="7.0"} 6.0 ${timestamp.millis}
-       |$name{$labelString,le="+Inf"} 6.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="1.0"} 2.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="4.0"} 4.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="6.0"} 5.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="7.0"} 6.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="+Inf"} 6.0 ${timestamp.millis}
        |${name}_count{$labelString} 6.0 ${timestamp.millis}
        |${name}_sum{$labelString} 23.0 ${timestamp.millis}
        |""".stripMargin

--- a/library/src/test/scala/com/monsanto/arch/kamon/prometheus/metric/HistogramSerialisationFixture.scala
+++ b/library/src/test/scala/com/monsanto/arch/kamon/prometheus/metric/HistogramSerialisationFixture.scala
@@ -40,9 +40,9 @@ trait HistogramSerialisationFixture {
   /** The snapshot as a string. */
   val snapshotString =
     s"""# TYPE $name histogram
-       |$name{$labelString,le="1.0"} 5.0 ${timestamp.millis}
-       |$name{$labelString,le="4.0"} 7.0 ${timestamp.millis}
-       |$name{$labelString,le="+Inf"} 7.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="1.0"} 5.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="4.0"} 7.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="+Inf"} 7.0 ${timestamp.millis}
        |${name}_count{$labelString} 7.0 ${timestamp.millis}
        |${name}_sum{$labelString} 13.0 ${timestamp.millis}
        |""".stripMargin

--- a/library/src/test/scala/com/monsanto/arch/kamon/prometheus/metric/MinMaxCounterSerialisationFixture.scala
+++ b/library/src/test/scala/com/monsanto/arch/kamon/prometheus/metric/MinMaxCounterSerialisationFixture.scala
@@ -40,9 +40,9 @@ trait MinMaxCounterSerialisationFixture {
   /** The snapshot as a string. */
   val snapshotString =
     s"""# TYPE $name histogram
-       |$name{$labelString,le="1.0"} 1.0 ${timestamp.millis}
-       |$name{$labelString,le="4.0"} 3.0 ${timestamp.millis}
-       |$name{$labelString,le="+Inf"} 3.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="1.0"} 1.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="4.0"} 3.0 ${timestamp.millis}
+       |${name}_bucket{$labelString,le="+Inf"} 3.0 ${timestamp.millis}
        |${name}_count{$labelString} 3.0 ${timestamp.millis}
        |${name}_sum{$labelString} 9.0 ${timestamp.millis}
        |""".stripMargin


### PR DESCRIPTION
fixes MonsantoCo/kamon-prometheus#16

Per https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details
histogram buckets should have the _bucket suffix.